### PR TITLE
Docs Addition - DNS Tests on NS CNAME CAA etc - dnscontrol Exclusion Logic Change

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,4 +1,10 @@
+# Owner: Amaan Ul Haq Siddiqui (@amaan-igs)
+
+# Default owner for all files
 * @amaan-igs
 
-/domains/ @amaan-igs/maintainers
-*.md @amaan-igs/maintainers
+# Owner for all Markdown files
+*.md @amaan-igs
+
+# Owner for all domain JSON files in /domains/
+/domains/*.json @amaan-igs

--- a/README.md
+++ b/README.md
@@ -1,17 +1,19 @@
-## Security Policy: Managing Critical DNS Records
+# Cloudflare-DNSControl
+
+## Security Policy: Root Domain Record Management
 
 **Important:**
 
-- Critical DNS records (MX, TXT, and all root-level records) are not managed or altered by DNSControl in this repository.
-- The purpose of this tooling is to enable developers, operations, and platform teams to request subdomains with valid reasons and their names via Pull Requests (PRs), ensuring a documented and auditable process.
-- Any changes to root-level DNS configurations (e.g., MX, TXT, NS, or A records for the apex domain) must be performed directly in the Cloudflare panel.
-- Access to the Cloudflare panel for root-level changes is restricted and requires written approval over email. No developer, operations, or platform team member may modify root-level DNS records without explicit authorization.
+- Only CAA records are managed as code at the root domain (apex) via DNSControl. All other root-level records (A, AAAA, MX, NS, TXT, etc.) are ignored and must be managed directly in the Cloudflare panel.
+- The only CAA records currently allowed are for certificate authorities: letsencrypt.org, amazon.com, amazontrust.com, awstrust.com, and amazonaws.com.
+- Subdomain requests and changes are managed via DNSControl and Pull Requests (PRs) for auditability and process control.
+- Any changes to other root-level DNS configurations require Cloudflare panel access and written approval. No developer, operations, or platform team member may modify root-level DNS records without explicit authorization.
 
 **Summary:**
 
-- Subdomain requests and changes are managed via DNSControl and PRs.
-- Root-level DNS changes require Cloudflare panel access and written approval.
-- This policy protects the integrity and security of the domain's core DNS setup.
+- Only CAA records for approved certificate authorities are managed as code at the root domain.
+- All other root-level DNS records are ignored by DNSControl and require manual management in Cloudflare.
+- Subdomain management is handled via PRs and DNSControl.
 
 ## Ignored DNS Records in DNSControl
 
@@ -19,12 +21,14 @@
 |-------------------------------|-----------|-----------------------------------------------------|----------------------------------------------------|
 | `*`                           | A         | Ignore all wildcard A records                        | Wildcard A records can expose all subdomains to unintended IPs, risking takeover or misrouting. |
 | `*._domainkey`                | TXT       | Ignore all DKIM TXT records for subdomains           | DKIM records are managed by mail providers; accidental changes can break email authentication. |
-| `@`                           | *         | Ignore all records at the root domain                | Root domain records are critical; accidental changes can break main website, mail, or cause outages. |
+| `@`                           | * (except CAA) | Ignore all records at the root domain except CAA     | Only CAA records for approved CAs are managed as code. All other root records are critical and must be managed manually. |
 | `_acme-challenge`             | TXT       | Ignore ACME challenge TXT records (SSL certs)        | SSL certificate issuance can fail or be hijacked if these are modified. |
 | `_discord`                    | TXT       | Ignore Discord verification TXT records              | Discord integrations may break or be hijacked.      |
 | `_dmarc`                      | TXT       | Ignore DMARC TXT records                             | DMARC policy changes can impact email deliverability and security. |
 | `_psl`                        | TXT       | Ignore Public Suffix List TXT records                | Public Suffix List changes can impact domain security and browser behavior. |
 | `ns[1-4]`                     | A,AAAA    | Ignore name server A/AAAA records                    | Name server records are critical; accidental changes can break DNS resolution for the entire domain. |
+
+> The following steps are informational and describe the underlying tools used in the repo. All team members the Dev, Ops, Platform, and AI teams should fork the repository or create a branch (e.g., `dns/<team-name>-subdomain-name`), add your `subdomain.json` file to the `domains` folder, and submit a pull request with the required details. No additional steps are necessary.
 
 ## DNSControl Quick Install
 

--- a/dnsconfig.js
+++ b/dnsconfig.js
@@ -157,15 +157,45 @@ records.push(TXT("_zone-updated", "\"" + Date.now().toString() + "\""));
 
 // Ignore auto-generated / managed records
 var ignored = [
-    IGNORE("\\*", "A"),
-    IGNORE("*._domainkey", "TXT"),
-    IGNORE("@", "*"),
-    IGNORE("_acme-challenge", "TXT"),
-    IGNORE("_discord", "TXT"),
-    IGNORE("_dmarc", "TXT"),
-    IGNORE("_psl", "TXT"),
-    IGNORE("ns[1-4]", "A,AAAA"),
-    IGNORE("go", "CNAME")
+    // ==============================
+    // ROOT DOMAIN (@) RECORDS
+    // ==============================
+    // Ignore standard record types at apex; only CAA will be managed explicitly
+    IGNORE("@", "A"),       // Root A record auto-managed or existing elsewhere
+    IGNORE("@", "AAAA"),    // Root AAAA record auto-managed or existing elsewhere
+    IGNORE("@", "CERT"),    // Certificate-related records, not managed manually
+    IGNORE("@", "CNAME"),   // Avoid conflicts with apex CNAME restrictions
+    IGNORE("@", "DNSKEY"),  // DNSSEC key records auto-generated
+    IGNORE("@", "DS"),      // Delegation signer for DNSSEC
+    IGNORE("@", "HTTPS"),   // Service binding for HTTPS (auto-managed)
+    IGNORE("@", "LOC"),     // Geolocation records, rarely managed
+    IGNORE("@", "MX"),      // Mail exchange records; keep existing, not altered
+    IGNORE("@", "NAPTR"),   // Naming authority pointer; usually auto
+    IGNORE("@", "NS"),      // Nameservers; managed by registrar/Cloudflare
+    IGNORE("@", "PTR"),     // Reverse DNS; not relevant for root
+    IGNORE("@", "SMIMEA"),  // Email certificate records, auto
+    IGNORE("@", "SRV"),     // Service records, often auto or managed elsewhere
+    IGNORE("@", "SSHFP"),   // SSH fingerprints, auto-generated
+    IGNORE("@", "SVCB"),    // Service binding for future protocols
+    IGNORE("@", "TLSA"),    // DANE TLS certs, auto
+    IGNORE("@", "TXT"),     // Other TXT records like SPF, DKIM may exist
+    IGNORE("@", "URI"),     // URI association records, rare
+
+    // ==============================
+    // WILDCARD / SPECIAL RECORDS
+    // ==============================
+    IGNORE("\\*", "A"),            // Wildcard A records; usually auto-managed
+    IGNORE("*._domainkey", "TXT"), // DKIM keys for email; auto-generated
+    IGNORE("_acme-challenge", "TXT"), // ACME challenge records for Let's Encrypt; auto
+    IGNORE("_discord", "TXT"),     // Specific service TXT records (Discord)  
+    IGNORE("_dmarc", "TXT"),       // DMARC policy; auto-managed
+    IGNORE("_psl", "TXT"),         // Public suffix list validation TXT records
+
+    // ==============================
+    // NAMESERVERS / SUBDOMAINS
+    // ==============================
+    IGNORE("ns[1-4]", "A,AAAA"),   // Legacy or sub-NS glue records; auto
+    IGNORE("go", "CNAME")          // Subdomain `go` CNAME for R2 Bucket as Cloudflare auto-manages it
 ];
 
 // Add internal ignore list

--- a/docs/filename-guide.md
+++ b/docs/filename-guide.md
@@ -1,0 +1,42 @@
+## Domain Structure
+To register a subdomain, submit a pull request with a new JSON file in the `domains` directory. For example, to register `example.runonaws.dev`, create a file named `example.json` in `domains/`.
+
+# Filename Guidelines
+To register a nested subdomain such as `blog.example.runonaws.dev`, use dots (.) in the filename: `blog.example.json`.
+
+Filename requirements:
+- Must be alphanumeric and lowercase. Dashes (-) are allowed as separators, but not consecutively.
+- Minimum 1 character, maximum 244 characters (excluding `.json`).
+- Each label (segment between dots) must be ≤ 63 characters.
+- File must end with `.json`.
+- Must not contain `runonaws.dev`.
+- Must not begin with a dot, or contain spaces or invalid characters.
+
+#### Invalid Filenames
+| Filename                | Issue                        |
+|------------------------|------------------------------|
+| .json                  | Empty filename               |
+| A.json                 | Uppercase letters            |
+| a..json                | Consecutive dots             |
+| .a.json                | Starts with a dot            |
+| a .json                | Contains a space             |
+| a$.json                | Non-alphanumeric character   |
+| a.json.json            | Multiple extensions          |
+| a.runonaws.dev.json    | Contains reserved string     |
+| a--a.json              | Consecutive dashes           |
+| blog._a.json           | Label starts with underscore |
+| abc123.aaa...aaa.json  | Label exceeds 63 characters  |
+| very.long.filename...json | Filename exceeds 244 characters |
+
+#### Valid Filenames
+| Filename                  | Why It's Valid              |
+|--------------------------|-----------------------------|
+| a.json                   | Minimum 1 character         |
+| example.json             | Lowercase and alphanumeric  |
+| blog.example.json        | Nested subdomain            |
+| my-blog.json             | Uses dashes correctly       |
+| mail._domainkey.example.json | Underscore not in root label |
+| _vercel.example.json     | Valid underscore usage      |
+| abc123.json              | Alphanumeric                |
+
+> Users may only register one single-letter subdomain to prevent domain squatting.

--- a/docs/json-structure-guide.md
+++ b/docs/json-structure-guide.md
@@ -1,0 +1,138 @@
+## Domain Structure
+To register a subdomain, submit a pull request with a new JSON file in the `domains` directory. For example, to register `example.runonaws.dev`, create a file named `example.json` in `domains/`.
+
+# JSON Structure
+
+### Example JSON File
+`domains/docs.json`:
+
+```json
+{
+  "owner": {
+    "username": "runonaws-dev",
+    "email": "contact@runonaws.dev"
+  },
+  "records": {
+    "CNAME": "docs.runonaws.dev"
+  },
+  "proxied": true
+}
+```
+
+#### owner (required)
+Contact information for the subdomain owner. Required fields:
+- `username`: Your GitHub username.
+- `email`: Contact email address.
+
+Example:
+```json
+{
+  "owner": {
+    "username": "your-github-username"
+  }
+}
+```
+
+#### records (required)
+Specify DNS records for your subdomain. Supported record types:
+
+##### A (IPv4 address)
+```json
+"A": ["192.0.2.1", "198.51.100.1"]
+```
+
+##### AAAA (IPv6 address)
+```json
+"AAAA": ["2001:db8::1", "2001:db8::2"]
+```
+
+##### CAA (Certificate Authority Authorization)
+```json
+"CAA": [
+  { "flags": 0, "tag": "issue", "value": "letsencrypt.org" }
+]
+```
+
+##### CNAME (Canonical Name)
+```json
+"CNAME": "your-site.runonaws.dev"
+```
+
+##### DS (DNSSEC Delegation Signer)
+```json
+"DS": [
+  {
+    "key_tag": 2371,
+    "algorithm": 13,
+    "digest_type": 2,
+    "digest": "..."
+  }
+]
+```
+
+##### MX (Mail Exchange)
+Simple form:
+```json
+"MX": [
+  "mx1.runonaws.dev",
+  "mx2.runonaws.dev"
+]
+```
+With priority:
+```json
+"MX": [
+  { "target": "mx1.runonaws.dev", "priority": 10 },
+  { "target": "mx2.runonaws.dev", "priority": 20 }
+]
+```
+
+##### NS (Name Server)
+```json
+"NS": ["ns1.runonaws.dev", "ns2.runonaws.dev"]
+```
+
+##### SRV (Service Record)
+```json
+"SRV": [
+  {
+    "priority": 10,
+    "weight": 5,
+    "port": 8080,
+    "target": "service.runonaws.dev"
+  }
+]
+```
+
+##### TLSA (TLS/SSL Certificate Association)
+```json
+"TLSA": [
+  {
+    "usage": 1,
+    "selector": 1,
+    "matching_type": 1,
+    "certificate": "..."
+  }
+]
+```
+
+##### TXT (Text Record)
+Single string:
+```json
+"TXT": "Some verification text"
+```
+List format:
+```json
+"TXT": ["part1", "part2"]
+```
+
+##### URL (Redirect)
+```json
+"URL": "https://runonaws.dev"
+```
+
+#### proxied (optional)
+Enable Cloudflare proxy:
+```json
+"proxied": true
+```
+> Users may only register one single-letter subdomain to prevent domain squatting.

--- a/domains/@.json
+++ b/domains/@.json
@@ -1,0 +1,15 @@
+{
+  "owner": {
+    "username": "amaan-igs",
+    "email": "amaanulhaq.s@outlook.com"
+  },
+  "records": {
+    "CAA": [
+      { "flags": 0, "tag": "issue", "value": "letsencrypt.org" },
+      { "flags": 0, "tag": "issue", "value": "amazon.com" },
+      { "flags": 0, "tag": "issue", "value": "amazontrust.com" },
+      { "flags": 0, "tag": "issue", "value": "awstrust.com" },
+      { "flags": 0, "tag": "issue", "value": "amazonaws.com" }
+    ]
+  }
+}

--- a/domains/stg.json
+++ b/domains/stg.json
@@ -1,0 +1,15 @@
+{
+	"owner": {
+		"username": "amaan-igs",
+		"email": "amaanulhaq.s@outlook.com"
+	},
+	"records": {
+		"NS": [
+			"ns-1051.awsdns-03.org",
+			"ns-493.awsdns-61.com",
+			"ns-851.awsdns-42.net",
+			"ns-1842.awsdns-38.co.uk"
+		]
+	},
+	"proxied": false
+}


### PR DESCRIPTION
This pull request introduces important updates to the DNS management and documentation for the repository. The main focus is on tightening security for root domain DNS records, clarifying ownership and record management, and providing clear guidelines for subdomain registration. The changes ensure that only approved CAA records are managed at the root level, all other critical root records are protected from accidental modification, and contributors have comprehensive instructions for submitting subdomain requests.

**Security and DNS Record Management**

* Updated the DNS ignore list in `dnsconfig.js` to explicitly ignore all root domain (`@`) record types except CAA, preventing accidental changes to critical DNS records. Only CAA records for approved certificate authorities are now managed as code.
* Added a root domain JSON file (`domains/@.json`) specifying CAA records for letsencrypt.org, amazon.com, amazontrust.com, awstrust.com, and amazonaws.com, in line with the new security policy.

**Ownership and Access Control**

* Revised `.github/CODEOWNERS` to clarify ownership: all files and domain JSON files are assigned to `@amaan-igs`, and all markdown files are also owned by `@amaan-igs`.

**Documentation and Contributor Guidance**

* Expanded `README.md` with a new security policy, emphasizing that only CAA records are managed at the root domain, and all other root-level records must be managed manually in Cloudflare with explicit approval. Subdomain requests are handled via PRs and DNSControl for auditability.
* Added `docs/filename-guide.md` and `docs/json-structure-guide.md` to provide clear, step-by-step instructions and validation rules for subdomain filename formats and JSON structure requirements, including examples of valid and invalid submissions. [[1]](diffhunk://#diff-1a2477f2b27598e294ab6d98b550277f1e81afcf94436990a137356018a0a529R1-R42) [[2]](diffhunk://#diff-09de625702e3b29a118b2b34356f7041ede18e3536ba58be860fedab61f53092R1-R138)

**Subdomain Management Example**

* Added `domains/stg.json` as an example of a subdomain registration, showing proper owner and NS record structure.