### PR TITLE
ci-fix: refine workflow triggers for push events and enhance pr

### DIFF
--- a/.github/workflows/publish-records.yml
+++ b/.github/workflows/publish-records.yml
@@ -1,11 +1,17 @@
-
 name: CF-DNSControl Pipeline
 
 on:
+  push:
+    branches:
+      - main
+    paths:
+      - "domains/*"
+      - ".github/workflows/publish-records.yml"
+      - "util/reserved.json"
+      - "dnsconfig.js"
   pull_request:
     branches:
       - main
-      - 'ci/*'
     paths:
       - "domains/*"
       - ".github/workflows/publish-records.yml"
@@ -16,6 +22,7 @@ on:
 jobs:
   preview:
     name: Preview DNS changes
+    if: github.event_name == 'pull_request' && github.event.pull_request.merged == true && github.event.pull_request.base.ref == 'main'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
This pull request updates the GitHub Actions workflow configuration for publishing DNS records. The main changes focus on refining when the workflow runs and under what conditions the DNS preview job is triggered.

Workflow trigger improvements:

* The workflow now runs on pushes to the `main` branch, but only when certain files are modified (`domains/*`, `.github/workflows/publish-records.yml`, `util/reserved.json`, or `dnsconfig.js`).
* The workflow continues to run on pull requests targeting the `main` branch, but removes support for `ci/*` branches.

Conditional job execution:

* The `preview` job is now restricted to only run when a pull request has been merged into the `main` branch, ensuring DNS previews are only generated for finalized changes.