### PR TITLE
chore: remove 'go' from reserved subdomains list as R2 Bucket auto ad…

### DIFF
--- a/utils/reserved.json
+++ b/utils/reserved.json
@@ -4,7 +4,6 @@
     "account",
     "accounts",
     "acme",
-    "go",
     "admin",
     "api",
     "app",


### PR DESCRIPTION
This pull request makes a small update to the `utils/reserved.json` file, removing the reserved word "go" from the list. This change frees up the word "go" to be used with R2 Bucket and DNS is managed outside of IaC because Cloudflare R2 Bucket automatically assign a type ```R2``` Record which is locked to alter and unique to Cloudflare hence EXCLUDED as well in dnsconfig.js 

```js
IGNORE("go", "CNAME")          // Subdomain `go` CNAME for R2 Bucket as Cloudflare auto-manages it
```