### PR TITLE
Ci/fix gh actions

### DIFF
--- a/.github/workflows/preview-records.yml
+++ b/.github/workflows/preview-records.yml
@@ -1,0 +1,42 @@
+name: Preview DNS Changes
+
+on:
+  pull_request:
+    branches:
+      - main
+    paths:
+      - "domains/*"
+      - ".github/workflows/preview-records.yml"
+      - "utils/reserved.json"
+      - "dnsconfig.js"
+  workflow_dispatch:
+
+jobs:
+  preview:
+    name: Preview DNS changes
+    if: github.event_name == 'pull_request' && github.event.pull_request.base.ref == 'main'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Generate creds.json
+        run: echo '{"cloudflare":{"TYPE":"CLOUDFLAREAPI","apitoken":"$CLOUDFLARE_API_TOKEN"}}' > creds.json
+      - name: DNSControl preview
+        uses: amaan-igs/dnscontrol-action@v1
+        id: dnscontrol_preview
+        env:
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+        with:
+          args: preview
+          config_file: dnsconfig.js
+          creds_file: creds.json
+      - name: Preview pull request comment
+        uses: unsplash/comment-on-pr@v1.3.0
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          msg: |
+            ## DNS Preview Results
+            ```
+            ${{ steps.dnscontrol_preview.outputs.preview_comment }}
+            ```
+          check_for_duplicate_msg: true

--- a/.github/workflows/publish-records.yml
+++ b/.github/workflows/publish-records.yml
@@ -1,4 +1,4 @@
-name: CF-DNSControl Pipeline
+name: Push DNS Changes
 
 on:
   push:
@@ -7,37 +7,11 @@ on:
     paths:
       - "domains/*"
       - ".github/workflows/publish-records.yml"
-      - "util/reserved.json"
-      - "dnsconfig.js"
-  pull_request:
-    branches:
-      - main
-    paths:
-      - "domains/*"
-      - ".github/workflows/publish-records.yml"
-      - "util/reserved.json"
+      - "utils/reserved.json"
       - "dnsconfig.js"
   workflow_dispatch:
 
 jobs:
-  preview:
-    name: Preview DNS changes
-    if: github.event_name == 'pull_request' && github.event.pull_request.base.ref == 'main'
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v4
-      - name: Generate creds.json
-        run: echo '{"cloudflare":{"TYPE":"CLOUDFLAREAPI","apitoken":"$CLOUDFLARE_API_TOKEN"}}' > creds.json
-      - name: DNSControl preview
-        uses: amaan-igs/dnscontrol-action@v1
-        id: dnscontrol_preview
-        env:
-          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
-        with:
-          args: preview
-          config_file: dnsconfig.js
-          creds_file: creds.json
-
   push:
     name: Push DNS changes
     if: github.event_name == 'push' && github.ref == 'refs/heads/main'


### PR DESCRIPTION
This pull request updates GitHub Actions workflows to improve the DNS records deployment process. The main changes involve splitting the preview and push workflows, correcting file path patterns, and cleaning up job definitions. The preview of DNS changes is now handled in a dedicated workflow triggered by pull requests, while the push workflow is streamlined to only handle deployments to production.

**Workflow separation and improvements:**

* Added a new workflow `.github/workflows/preview-records.yml` to preview DNS changes on pull requests targeting `main`. This workflow runs DNSControl in preview mode and posts the results as a comment on the pull request.
* Removed the preview job and pull request trigger from `.github/workflows/publish-records.yml`, so it now only handles pushing DNS changes to production when changes are pushed to `main`.

**File path and naming corrections:**

* Fixed file path patterns from `util/reserved.json` to `utils/reserved.json` in workflow triggers for both preview and push workflows.
* Updated workflow names for clarity: the push workflow is now named "Push DNS Changes" instead of "CF-DNSControl Pipeline".